### PR TITLE
Fix NullPointerException in Project Statistics

### DIFF
--- a/jmix-studio.xml
+++ b/jmix-studio.xml
@@ -2,6 +2,19 @@
 <project version="4">
   <component name="JmixDataStoreSettingsManager">
     <moduleSettings>
+      <entry key="ProjectManagement.main">
+        <ModuleSettings>
+          <option name="dataStoreOptionsV2">
+            <map>
+              <entry key="main">
+                <value>
+                  <DataStoreSettingsV2 />
+                </value>
+              </entry>
+            </map>
+          </option>
+        </ModuleSettings>
+      </entry>
       <entry key="com.company.ProjectManagement.main">
         <ModuleSettings>
           <option name="dataStoreOptionsV2">

--- a/src/main/java/com/company/projectmanagement/app/ProjectStatsService.java
+++ b/src/main/java/com/company/projectmanagement/app/ProjectStatsService.java
@@ -27,7 +27,12 @@ public class ProjectStatsService {
             stat.setId(project.getId());
             stat.setProjectName(project.getName());
             stat.setTasksCount(project.getTasks().size());
-            Integer plannedEfforts = project.getTasks().stream().map(Task::getEstimation).reduce(0, Integer::sum);
+
+            Integer plannedEfforts = 0;
+            for (Task task : project.getTasks()) {
+                plannedEfforts += task.getEstimation() != null ? task.getEstimation() : 0;
+            }
+
             stat.setPlannedEfforts(plannedEfforts);
             stat.setActualEfforts(getActualEfforts(project.getId()));
             return stat;


### PR DESCRIPTION
**Update `ProjectStatsService.java` to handle cases where a task's estimation is null.**

This PR addresses an issue where the application throws a `NullPointerException` if a task is created without specifying the estimation field. This prevents the Project Statistics page from opening.

- **Fix**: Added a null check for the estimation field in `ProjectStatsService.java`.
- **Alternative Solution**: Consider making the estimation field mandatory in the UI to prevent null values from being submitted.

![Screenshot from 2024-12-26 17-23-14](https://github.com/user-attachments/assets/57acc9ee-c6dc-46b3-9b8f-8e2871e9d8e6)

I hope this fix is helpful!
Thank you for the repository and the course material.